### PR TITLE
feat(locations): associate movies with multiple locations

### DIFF
--- a/db/migrations/20190529092420_create_locations.js
+++ b/db/migrations/20190529092420_create_locations.js
@@ -1,0 +1,12 @@
+'use strict';
+
+exports.up = (Knex) => {
+  return Knex.schema.createTable('locations', (table) => {
+    table.increments('id').primary();
+    table.text('name').notNullable();
+  });
+};
+
+exports.down = (Knex) =>  {
+  return Knex.schema.dropTable('locations');
+};

--- a/db/migrations/20190529173422_create_locations_movies_table.js
+++ b/db/migrations/20190529173422_create_locations_movies_table.js
@@ -1,0 +1,14 @@
+
+'use strict';
+
+exports.up = (Knex) => {
+  return Knex.schema.createTable('locations_movies', (table) => {
+    table.integer('movie_id').references('movies.id').notNullable();
+    table.integer('location_id').references('locations.id').notNullable();
+    table.increments('id').primary();
+  });
+};
+
+exports.down = (Knex) =>  {
+  return Knex.schema.dropTable('locations_movies');
+};

--- a/lib/models/location.js
+++ b/lib/models/location.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const Bookshelf = require('../libraries/bookshelf');
+
+module.exports = Bookshelf.Model.extend({
+  tableName: 'locations',
+  serialize: function () {
+    return {
+      id: this.get('id'),
+      name: this.get('name'),
+      object: 'location'
+    };
+  }
+});

--- a/lib/models/locations_movies.js
+++ b/lib/models/locations_movies.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const Bookshelf = require('../libraries/bookshelf');
+const Location  = require('./location');
+const Movie     = require('./movie');
+
+module.exports = Bookshelf.Model.extend({
+  tableName: 'locations_movies',
+  location: function () {
+    return this.belongsTo(Movie, 'movie_id', 'movies.id');
+  },
+  movie: function () {
+    return this.belongsTo(Location, 'location_id', 'location.id');
+  },
+  serialize: function () {
+    return {
+      movie_id: this.get('movie_id'),
+      location_id: this.get('location_id'),
+      object: 'location_movie'
+    };
+  }
+});

--- a/lib/models/movie.js
+++ b/lib/models/movie.js
@@ -1,14 +1,19 @@
 'use strict';
 
 const Bookshelf = require('../libraries/bookshelf');
+const Location  = require('./location');
 
 module.exports = Bookshelf.Model.extend({
   tableName: 'movies',
+  locations: function () {
+    return this.belongsToMany(Location);
+  },
   serialize: function () {
     return {
       id: this.get('id'),
       title: this.get('title'),
       release_year: this.get('release_year'),
+      locations: this.related('locations'),
       object: 'movie'
     };
   }

--- a/lib/plugins/features/movies/controller.js
+++ b/lib/plugins/features/movies/controller.js
@@ -1,7 +1,8 @@
 'use strict';
 
-const Movie = require('../../../models/movie');
-const Movies = Movie.collection();
+const Movie         = require('../../../models/movie');
+const Location      = require('../../../models/location');
+const LocationMovie = require('../../../models/locations_movies');
 
 exports.create = async (payload) => {
   const movie = await new Movie().save(payload);
@@ -10,7 +11,8 @@ exports.create = async (payload) => {
 };
 
 exports.find = async (query) => {
-  const movies = Movies.query((queryBuilder) => {
+  const Movies = Movie.collection();
+  return Movies.query((queryBuilder) => {
 
     if (query.title) {
       queryBuilder.where('title', '=', query.title);
@@ -21,7 +23,19 @@ exports.find = async (query) => {
     } if (query.end_year) {
       queryBuilder.where('release_year', '<=', query.end_year);
     }
+  }).fetch({ withRelated: ['locations'] });
+};
+exports.addLocation = async (movieId, payload) => {
+  let location = await new Location().query((queryBuilder) => {
+    queryBuilder.where('name', 'like', payload.name);
   }).fetch();
 
-  return movies;
+  if (!location) {
+    location = await new Location().save(payload);
+  }
+
+  const locationId = location.id;
+  const set = await new LocationMovie().save({ location_id: locationId, movie_id: parseInt(movieId) });
+  return set;
 };
+

--- a/lib/plugins/features/movies/index.js
+++ b/lib/plugins/features/movies/index.js
@@ -1,8 +1,9 @@
 'use strict';
 
-const Controller           = require('./controller');
-const MovieValidator       = require('../../../validators/movie');
-const MovieSearchValidator = require('../../../validators/movieSearch');
+const Controller             = require('./controller');
+const MovieLocationValidator = require('../../../validators/movieLocation');
+const MovieSearchValidator   = require('../../../validators/movieSearch');
+const MovieValidator         = require('../../../validators/movie');
 
 exports.register = (server, options, next) => {
   server.route([{
@@ -28,7 +29,20 @@ exports.register = (server, options, next) => {
         query: MovieSearchValidator
       }
     }
-  }]);
+  },
+  {
+    method: 'POST',
+    path: '/movies/{id}/location',
+    config: {
+      handler: (request, reply) => {
+        reply(Controller.addLocation(request.params.id, request.payload));
+      },
+      validate: {
+        payload: MovieLocationValidator
+      }
+    }
+  }
+  ]);
 
   next();
 };

--- a/lib/validators/movieLocation.js
+++ b/lib/validators/movieLocation.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const Joi = require('joi');
+
+module.exports = Joi.object().keys({
+  name: Joi.string().min(1).max(255).required()
+});

--- a/test/models/movie.test.js
+++ b/test/models/movie.test.js
@@ -13,6 +13,7 @@ describe('movie model', () => {
         'id',
         'title',
         'release_year',
+        'locations',
         'object'
       ]);
     });

--- a/test/plugins/features/movies/index.test.js
+++ b/test/plugins/features/movies/index.test.js
@@ -20,4 +20,22 @@ describe('movies integration', () => {
 
   });
 
+  describe('add', () => {
+
+    it('adds a new location to a movie', () => {
+      return Movies.inject({
+        url: '/movies/1/location',
+        method: 'POST',
+        payload: { name: 'Soma' }
+      })
+      .then((response) => {
+        expect(response.statusCode).to.eql(200);
+        expect(response.result.object).to.eql('location_movie');
+        expect(response.result.movie_id).to.eql(1);
+        expect(response.result.location_id).to.eql(1);
+      });
+    });
+
+  });
+
 });


### PR DESCRIPTION
why: needed to associate movies with multiple locations
what: 
-creates migrations for locations and locations_movies tables
-adds bookshelf models for locations and locations_movies.
-adds controller for adding new locations to movies
-adds endpoints for adding new locations to movies
detail:
POST /movies/{id}/locations to add new locations to a movie
