### PR TITLE
 feat(migrate): adds a migration to drop not null constraint to name and to drop title

### DIFF
--- a/db/migrations/20190603103434_drop_title_from_movies.js
+++ b/db/migrations/20190603103434_drop_title_from_movies.js
@@ -1,0 +1,22 @@
+'use strict';
+
+exports.up = (Knex) => {
+  return Knex.schema.table('movies', (table) => {
+    table.dropColumn('title');
+  })
+  .then(() => {
+    return Knex.raw('ALTER TABLE movies ADD CONSTRAINT movies_name_not_null CHECK (name IS NOT NULL) NOT VALID')
+    .then(() => {
+      return Knex.raw('ALTER TABLE movies VALIDATE CONSTRAINT movies_name_not_null');
+    });
+  });
+};
+
+exports.down = (Knex) => {
+  return Knex.schema.table('movies', (table) => {
+    table.text('title');
+  })
+  .then(() => {
+    return Knex.raw('ALTER TABLE movies DROP CONSTRAINT movies_name_not_null');
+  });
+};


### PR DESCRIPTION
**what:**
adds a migration that drops the not null constraint from name column and drops title column
**why:**
-now that we have no use or need for title column in our api it is safe for us to drop the column and add a not null constraint to name column to maintain the same functionality from before  